### PR TITLE
Feature: Add mock service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Init velocitas project
         run: |
           cd runtime-local/test
-          velocitas init
+          velocitas init -v
 
       - name: Run integration tests for runtime-local
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Init velocitas project
         run: |
           cd runtime-k3d/test
-          velocitas init
+          velocitas init -v
 
       - name: Run integration tests for k3d
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
         additional_dependencies:
           - flake8-bugbear
           - flake8-unused-arguments
+        args: ["--ignore=E203"]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5

--- a/README.md
+++ b/README.md
@@ -2,27 +2,53 @@
 
 [![License: Apache](https://img.shields.io/badge/License-Apache-yellow.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-A Velocitas CLI package containing all available and supported Velocitas runtimes.
+A Velocitas CLI package containing all available and supported Velocitas runtimes and deployments.
 
-## Runtime Local
+## Runtimes
 
-This runtime brings up a local runtime, based on Docker and dapr, consisting of the following items:
+This package contains the following runtimes:
 
-* Mosquitto MQTT broker
-* Kuksa Vehicle Databroker
-* Kuksa Seat Service
-* Kuksa Feeder Can
+* [Local](./runtime-local/README.md)
+* [Kubernetes (K3D)](./runtime-k3d/README.md)
 
-## Runtime K3D
+## Runtime Configuration (runtime.json)
 
-This runtime brings up a Kubernetes cluster into which Velocitas Vehicle Apps can be deployed.
-It consists of the following items:
+This JSON file contains an array of services which should be started by all runtimes. Every service entry
+consists of a unique `id`, its provided `interfaces` and its key-value based `config`.
 
-* Mosquitto MQTT broker
-* Kuksa Vehicle Databroker
-* Kuksa Seat Service
-* Kuksa Feeder Can
 
-## Deployment K3D
+### Configuration Values
+For config values, here is a list of supported key-value pairs:
 
-This deployment enables the development environment to deploy Velocitas Vehicle Apps into the K3D runtime.
+| Key | Value examples | Description |
+|:----|:--|:------|
+`no-dapr` | `"true"`, `"false"` | If set to `"true"` the service will not use dapr when middleware is configured to dapr. Useful for enabling services like MQTT or a database.
+`enabled` | `"true"`, `"false"` | If set to `"false"` the service will not be started by the runtimes. Defaults to `"true"`.
+`image` | `ghcr.io/eclipse/kuksa.val.feeders/dbc2val:v0.1.1` | A fully qualified URI to a OCI compliant container image located within a container registry
+`arg` | `-c` | Argument to be passed to the spawned service. Can be passed multiple times for multiple arguments; arguments are forwarded in the order of definition in that case.
+`env` | `foo=bar` | Environment variable key-value pair to be passed to the spawned service.
+`mount` | `/config/feedercan/:/data` | Mount `from_host:to_container` pair to pass to the spawned service. Can be passed multiple times for multiple mounts. Both paths need to be **absolute**.
+`port` | `8080` | Port exposed by the spawned service. Can be passed multiple times for multiple ports.
+`port-forward` | `8080:8080` | Port forwarded from containerized service to the host. Can be passed multiple times for multiple forwards.
+`start-pattern` | `".*mosquitto version \\d+\\.\\d+\\.\\d+ running\n"` | Regex pattern which identifies a proper startup of the service. If passed multiple times, all patterns have to match.
+
+### Dynamic value resolution in configuration
+
+Each of the supported keys may need to use dynamic values i.e. from [Velocitas CLI variables](https://github.com/eclipse-velocitas/cli/blob/main/docs/features/VARIABLES.md).
+
+To use these in the `runtime.json`'s config keys, refer to the variable name within a `${{ }}` block, i.e. `${{ myVariable }}`.
+
+In addition to CLI variables, some builtin variables are available:
+
+| Variable name | Description |
+|:---|:----|
+`builtin.package_dir` | The path to the current package root which contains the package's `manifest.json`
+ `builtin.cache.cache_key` | The value of the cache entry with key *cache_key*, e.g. `builtin.cache.vspec_file_path`
+
+Finally, sometimes a single variable substitution is not enough. Among others, you may want to look up a file in a directory and - if it does not exist - fall back to a default file provided by the package. This is where function execution within value entries comes to your rescue.
+
+Available functions:
+
+Function | Description
+:---|:---
+`$pathInWorkspaceOrPackage( <relative_path> )` | Resolves a path dynamically either to the local project workspace, if the file is available or falls back to a file in the package repository. If none of these files is available an exception is raised.

--- a/manifest.json
+++ b/manifest.json
@@ -10,39 +10,10 @@
                     "executable": "./runtime-local/src/ensure-dapr.sh"
                 },
                 {
-                    "id": "run-mosquitto",
+                    "id": "run-service",
                     "executable": "python3",
                     "args": [
-                        "./runtime-local/src/run-service.py",
-                        "mqtt-broker"
-                    ]
-                },
-                {
-                    "id": "run-vehicledatabroker",
-                    "executable": "python3",
-                    "args": [
-                        "./runtime-local/src/run-service.py",
-                        "vehicledatabroker"
-                    ]
-                },
-                {
-                    "id": "run-vehicledatabroker-cli",
-                    "executable": "./runtime-local/src/run-vehicledatabroker-cli.sh"
-                },
-                {
-                    "id": "run-feedercan",
-                    "executable": "python3",
-                    "args": [
-                        "./runtime-local/src/run-service.py",
-                        "feedercan"
-                    ]
-                },
-                {
-                    "id": "run-vehicleservices",
-                    "executable": "python3",
-                    "args": [
-                        "./runtime-local/src/run-service.py",
-                        "seatservice"
+                        "./runtime-local/src/run_service.py"
                     ]
                 },
                 {
@@ -100,6 +71,12 @@
                     "type": "string",
                     "description": "Path to the file describing your custom runtime configuration.",
                     "default": "runtime.json"
+                },
+                {
+                    "name": "mockFilePath",
+                    "type": "string",
+                    "description": "Path to the mocking configuration for the mock service",
+                    "default": "mock.py"
                 }
             ]
         },
@@ -167,6 +144,12 @@
                     "type": "string",
                     "description": "Path to the file describing your custom runtime configuration.",
                     "default": "runtime.json"
+                },
+                {
+                    "name": "mockFilePath",
+                    "type": "string",
+                    "description": "Path to the mocking configuration for the mock service",
+                    "default": "mock.py"
                 }
             ]
         },

--- a/mock.py
+++ b/mock.py
@@ -1,0 +1,126 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+from lib.animator import RepeatMode
+from lib.dsl import (
+    create_animation_action,
+    create_behavior,
+    create_set_action,
+    get_datapoint_value,
+    mock_datapoint,
+)
+from lib.trigger import ClockTrigger, EventTrigger, EventType
+
+mock_datapoint(
+    path="Vehicle.Speed",
+    initial_value=0.0,
+    behaviors=[
+        create_behavior(
+            trigger=ClockTrigger(0),
+            action=create_animation_action(
+                duration=10.0,
+                repeat_mode=RepeatMode.REPEAT,
+                values=[0, 30.0, 50.0, 70.0, 100.0, 70.0, 50.0, 30.0, 0.0],
+            ),
+        )
+    ],
+)
+
+mock_datapoint(
+    path="Vehicle.Cabin.Seat.Row1.Pos1.Position",
+    initial_value=0,
+    behaviors=[
+        create_behavior(
+            trigger=EventTrigger(EventType.ACTUATOR_TARGET),
+            action=create_animation_action(
+                duration=10.0,
+                values=["$self", "$event.value"],
+            ),
+        )
+    ],
+)
+
+mock_datapoint(
+    path="Vehicle.Body.Windshield.Front.Wiping.System.Mode",
+    initial_value="STOP_HOLD",
+    behaviors=[
+        create_behavior(
+            trigger=EventTrigger(EventType.ACTUATOR_TARGET),
+            action=create_set_action("$event.value"),
+        )
+    ],
+)
+
+mock_datapoint(
+    path="Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition",
+    initial_value=0,
+    behaviors=[
+        create_behavior(
+            trigger=EventTrigger(EventType.ACTUATOR_TARGET),
+            action=create_set_action("$event.value"),
+        )
+    ],
+)
+
+mock_datapoint(
+    path="Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition",
+    initial_value=0,
+    behaviors=[
+        create_behavior(
+            trigger=EventTrigger(EventType.ACTUATOR_TARGET),
+            condition=lambda ctx: get_datapoint_value(
+                ctx, "Vehicle.Body.Windshield.Front.Wiping.System.Mode"
+            )
+            == "EMERGENCY_STOP",
+            action=create_set_action(0),
+        ),
+        create_behavior(
+            trigger=EventTrigger(EventType.ACTUATOR_TARGET),
+            condition=lambda ctx: get_datapoint_value(
+                ctx, "Vehicle.Body.Windshield.Front.Wiping.System.Mode"
+            )
+            == "STOP_HOLD",
+            action=create_animation_action(
+                duration=10.0,
+                values=[
+                    "$self",
+                    "$Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition",
+                ],
+            ),
+        ),
+        create_behavior(
+            trigger=EventTrigger(EventType.ACTUATOR_TARGET),
+            condition=lambda ctx: get_datapoint_value(
+                ctx, "Vehicle.Body.Windshield.Front.Wiping.System.Mode"
+            )
+            == "WIPE",
+            action=create_animation_action(
+                duration=10.0,
+                values=[
+                    "$self",
+                    "$Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition",
+                ],
+            ),
+        ),
+    ],
+)
+
+mock_datapoint(
+    path="Vehicle.Cabin.HVAC.IsFrontDefrosterActive",
+    initial_value=False,
+    behaviors=[
+        create_behavior(
+            EventTrigger(EventType.ACTUATOR_TARGET), create_set_action("$event.value")
+        )
+    ],
+)

--- a/runtime-k3d/README.md
+++ b/runtime-k3d/README.md
@@ -1,0 +1,3 @@
+# Runtime K3D
+
+A runtime which uses Kubernetes to start up a development runtime.

--- a/runtime-k3d/src/requirements.txt
+++ b/runtime-k3d/src/requirements.txt
@@ -1,3 +1,3 @@
 yaspin==2.3.0
-ruamel.yaml==0.17.22
+ruamel.yaml==0.17.32
 velocitas_lib

--- a/runtime-k3d/src/runtime/deployment/config/helm/templates/mockservice.yaml
+++ b/runtime-k3d/src/runtime/deployment/config/helm/templates/mockservice.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2023 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Values.imageMockservice.name}}
+  labels:
+    app: {{.Values.imageMockservice.name}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Values.imageMockservice.name}}
+  template:
+    metadata:
+      labels:
+        app: {{.Values.imageMockservice.name}}
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "{{.Values.imageMockservice.name}}"
+        dapr.io/log-level: "debug"
+        dapr.io/config: "config"
+        dapr.io/app-protocol: "grpc"
+    spec:
+      containers:
+        - name: {{.Values.imageMockservice.name}}
+          image: {{.Values.imageMockservice.repository}}:{{.Values.imageMockservice.tag}}
+          imagePullPolicy: {{.Values.imageMockservice.pullPolicy}}
+        {{- if .Values.imageMockservice.environmentVariables}}
+          env:
+          {{- range .Values.imageMockservice.environmentVariables }}
+            - name: {{ .name }}
+              value: "{{ .value }}"
+          {{- end }}
+        {{- end }}
+          volumeMounts:
+            - name: mock
+              {{- with (index .Values.imageMockservice.mounts 0) }}
+              mountPath: {{ .from }}
+              {{- end }}
+              subPath: mock.py
+      volumes:
+        - name: mock
+          configMap:
+            name: mock-config

--- a/runtime-k3d/src/runtime/deployment/gen_helm.py
+++ b/runtime-k3d/src/runtime/deployment/gen_helm.py
@@ -78,6 +78,13 @@ def generate_values_by_service(service: Service) -> dict[str, Any]:
     if service.config.ports:
         value_spec[value_spec_key]["ports"] = generate_ports_spec(service.config)
 
+    value_spec[value_spec_key]["mounts"] = list()
+    for mount in service.config.mounts:
+        from_to = mount.split(":")
+        value_spec[value_spec_key]["mounts"].append(
+            {"id": "foo", "from": from_to[0], "to": from_to[1]}
+        )
+
     return value_spec
 
 
@@ -89,7 +96,7 @@ def generate_values_file(output_path: str):
         f.write(yaml.dump_all(services).replace("---", ""))
 
 
-def copy_helm_chart(output_path: str):
+def copy_helm_chart_and_templates(output_path: str):
     shutil.copytree(
         f"{get_package_path()}/runtime-k3d/src/runtime/deployment/config/helm",
         output_path,
@@ -100,10 +107,20 @@ def copy_helm_chart(output_path: str):
         dirs_exist_ok=True,
     )
 
+    # only keep the templates of the services we use
+    templates_path = os.path.join(output_path, "templates")
+    allowed_files_in_templates = [
+        f"{service.id}.yaml" for service in get_services(verbose=False)
+    ]
+    allowed_files_in_templates += ["_helpers.tpl", "bash.yaml", "persistentVolume.yaml"]
+    for template_file in os.listdir(templates_path):
+        if template_file not in allowed_files_in_templates:
+            os.remove(os.path.join(templates_path, template_file))
+
 
 def gen_helm(output_path: str):
     os.makedirs(output_path, exist_ok=True)
-    copy_helm_chart(output_path)
+    copy_helm_chart_and_templates(output_path)
     generate_values_file(output_path)
 
 

--- a/runtime-k3d/src/runtime/deployment/gen_podspec.py
+++ b/runtime-k3d/src/runtime/deployment/gen_podspec.py
@@ -24,7 +24,7 @@ from velocitas_lib.services import ServiceSpecConfig, get_services, parse_servic
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "deployment"))
 
-from lib import create_cluster_ip_spec, generate_nodeport  # noqa: E402
+from deployment.lib import create_cluster_ip_spec, generate_nodeport  # noqa: E402
 
 
 def find_service_spec(lst: list[dict[str, Any]], kind: str, name: str) -> int:

--- a/runtime-k3d/test/.velocitas.json
+++ b/runtime-k3d/test/.velocitas.json
@@ -8,5 +8,8 @@
             "name": "devenv-devcontainer-setup",
             "version": "v1.1.8"
         }
-    ]
+    ],
+    "variables": {
+        "language": "python"
+    }
 }

--- a/runtime-k3d/test/integration/integration_test.py
+++ b/runtime-k3d/test/integration/integration_test.py
@@ -37,8 +37,7 @@ image_reg = {compile(r"localhost:12345/sampleapp\s+local.+"): False}
 pods_regs = {
     compile(r".*mqttbroker-.+-.+\s+1/1\s+Running.*"): False,
     compile(r".*bash-.+-.+\s+1/1\s+Running.*"): False,
-    compile(r".*seatservice-.+-.+\s+2/2\s+Running.*"): False,
-    compile(r".*feedercan-.+-.+\s+2/2\s+Running.*"): False,
+    compile(r".*mockservice-.+-.+\s+2/2\s+Running.*"): False,
     compile(r".*vehicledatabroker-.+-.+\s+2/2\s+Running.*"): False,
     compile(r".*zipkin-.+-.+\s+1/1\s+Running.*"): False,
     compile(r".*sampleapp-.+-.+\s+2/2\s+Running.*"): False,

--- a/runtime-local/README.md
+++ b/runtime-local/README.md
@@ -1,0 +1,3 @@
+# Runtime Local
+
+A runtime without container management system (like Kubernetes). It supports either the dapr middleware or direct (native) usage of gRPC and MQTT to communicate between different services.

--- a/runtime-local/src/local_lib.py
+++ b/runtime-local/src/local_lib.py
@@ -22,20 +22,7 @@ from typing import Dict, List, Optional, Tuple
 
 from velocitas_lib import create_log_file, get_script_path
 from velocitas_lib.middleware import MiddlewareType, get_middleware_type
-from velocitas_lib.services import Service, get_services
-
-
-def get_specific_service(service_id: str) -> Service:
-    """Return the specified service as Python object."""
-    services = get_services()
-    services = list(filter(lambda service: service.id == service_id, services))
-    if len(services) == 0:
-        raise RuntimeError(f"Service with id '{service_id}' not defined")
-    if len(services) > 1:
-        raise RuntimeError(
-            f"Multiple service definitions of id '{service_id}' found, which to take?"
-        )
-    return services[0]
+from velocitas_lib.services import Service
 
 
 def get_dapr_sidecar_args(

--- a/runtime-local/src/run-dapr-sidecar.py
+++ b/runtime-local/src/run-dapr-sidecar.py
@@ -16,7 +16,7 @@ import argparse
 import subprocess
 from typing import Optional
 
-from lib import get_dapr_sidecar_args
+from local_lib import get_dapr_sidecar_args
 
 
 def start_sidecar(

--- a/runtime-local/src/run-vehicle-app.py
+++ b/runtime-local/src/run-vehicle-app.py
@@ -16,7 +16,7 @@ import argparse
 import subprocess
 from typing import Optional
 
-from lib import MiddlewareType, get_dapr_sidecar_args, get_middleware_type
+from local_lib import MiddlewareType, get_dapr_sidecar_args, get_middleware_type
 
 from velocitas_lib import get_services
 

--- a/runtime-local/src/runtime-up.py
+++ b/runtime-local/src/runtime-up.py
@@ -17,7 +17,7 @@ import subprocess
 import time
 from typing import Dict
 
-from lib import run_service, stop_container, stop_service
+from local_lib import run_service, stop_container, stop_service
 from yaspin import yaspin
 
 from velocitas_lib import get_log_file_name
@@ -57,8 +57,13 @@ def run_services() -> None:
 def wait_while_processes_are_running():
     while len(spawned_processes) > 0:
         time.sleep(1)
-        for process in spawned_processes.values():
-            process.poll()
+        for name, process in spawned_processes.items():
+            poll_result = process.poll()
+
+            if isinstance(poll_result, int):
+                print(f"Process terminated: {name!r} result: {poll_result}")
+                del spawned_processes[name]
+                break
 
 
 def terminate_spawned_processes():

--- a/runtime-local/test/integration/integration_test.py
+++ b/runtime-local/test/integration/integration_test.py
@@ -44,6 +44,7 @@ regex_mqtt: Pattern[str] = compile(r"✅.* Starting service mqtt")
 regex_vdb: Pattern[str] = compile(r"✅.* Starting service vehicledatabroker")
 regex_seatservice: Pattern[str] = compile(r"✅.* Starting service seatservice")
 regex_feedercan: Pattern[str] = compile(r"✅.* Starting service feedercan")
+regex_mockservice: Pattern[str] = compile(r"✅.* Starting service mockservice")
 timeout_sec: float = 180
 
 
@@ -71,9 +72,12 @@ def test_runtime_up_successfully():
 
 def test_run_sevices_separately_successfully():
     create_dummy_vspec_file()
-    assert run_command_until_logs_match(f"{command} run-mosquitto", regex_mqtt)
-    assert run_command_until_logs_match(f"{command} run-vehicledatabroker", regex_vdb)
     assert run_command_until_logs_match(
-        f"{command} run-vehicleservices", regex_seatservice
+        f"{command} run-service mqtt-broker", regex_mqtt
     )
-    assert run_command_until_logs_match(f"{command} run-feedercan", regex_feedercan)
+    assert run_command_until_logs_match(
+        f"{command} run-service vehicledatabroker", regex_vdb
+    )
+    assert run_command_until_logs_match(
+        f"{command} run-service mockservice", regex_mockservice
+    )

--- a/runtime-local/test/test_run_service.py
+++ b/runtime-local/test/test_run_service.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 Robert Bosch GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# flake8: noqa: U100 unused argument (because of pytest.fixture)
+
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from run_service import main
+
+
+@pytest.fixture()
+def set_env_vars():
+    os.environ["runtimeFilePath"] = "./runtime.json"
+    os.environ["VELOCITAS_WORKSPACE_DIR"] = "."
+    os.environ["VELOCITAS_CACHE_DATA"] = '{"vspec_file_path":""}'
+    os.environ["mockFilePath"] = "mock.py"
+
+
+def test_run_service__invalid_service_id__prints_available_services(
+    capsys, set_env_vars
+):
+    main("foo_bar_baz")
+
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == """runtime.json path redirected to runtime.json
+Error: Service with id 'foo_bar_baz' not defined
+Available services:
+ * 'mqtt-broker'
+ * 'vehicledatabroker'
+ * 'mockservice'
+"""
+    )

--- a/runtime.json
+++ b/runtime.json
@@ -88,6 +88,10 @@
         ],
         "config": [
             {
+                "key": "enabled",
+                "value": "false"
+            },
+            {
                 "key": "image",
                 "value": "ghcr.io/eclipse/kuksa.val.services/seat_service:v0.2.0"
             },
@@ -117,6 +121,10 @@
         "id": "feedercan",
         "interfaces": [],
         "config": [
+            {
+                "key": "enabled",
+                "value": "false"
+            },
             {
                 "key": "image",
                 "value": "ghcr.io/eclipse/kuksa.val.feeders/dbc2val:v0.1.1"
@@ -148,6 +156,28 @@
             {
                 "key": "mount",
                 "value": "${{ builtin.package_dir }}/config/feedercan/:/data"
+            },
+            {
+                "key": "start-pattern",
+                "value": ".*[cC]onnected to data broker.*"
+            }
+        ]
+    },
+    {
+        "id": "mockservice",
+        "interfaces": [],
+        "config": [
+            {
+                "key": "image",
+                "value": "ghcr.io/boschglobal/kuksa.val.services/mock_service:latest"
+            },
+            {
+                "key": "env",
+                "value": "VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker"
+            },
+            {
+                "key": "mount",
+                "value": "$pathInWorkspaceOrPackage( ${{ mockFilePath }} ):/mock.py"
             },
             {
                 "key": "start-pattern",

--- a/set_cli_env.sh
+++ b/set_cli_env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export VELOCITAS_WORKSPACE_DIR=.
+export VELOCITAS_CACHE_DATA="{\"vspec_file_path\":\"vss.json\"}"
+export runtimeFilePath=./runtime.json
+export mockFilePath=./mock.py

--- a/velocitas_lib/test/test_services.py
+++ b/velocitas_lib/test/test_services.py
@@ -1,0 +1,31 @@
+import os
+
+import pytest
+
+from velocitas_lib import get_package_path, get_workspace_dir
+from velocitas_lib.services import resolve_functions
+
+
+def test_resolve_functions__unknown_function__raises_exception():
+    with pytest.raises(RuntimeError, match="Unsupported function: 'foo'!"):
+        resolve_functions("$foo( asd )")
+
+
+def test_resolve_functions__pathInWorkspaceOrPackage__file_missing__raises_exception():
+    with pytest.raises(
+        RuntimeError, match="Path 'asd' not found in workspace or package!"
+    ):
+        resolve_functions("$pathInWorkspaceOrPackage( asd )")
+
+
+def test_resolve_functions__pathInWorkspaceOrPackage__file_exists_in_workspace():
+    assert resolve_functions(
+        "$pathInWorkspaceOrPackage( manifest.json )"
+    ) == os.path.join(get_workspace_dir(), "manifest.json")
+
+
+def test_resolve_functions__pathInWorkspaceOrPackage__file_exists_in_package():
+    os.environ["VELOCITAS_WORKSPACE_DIR"] = ".."
+    assert resolve_functions(
+        "$pathInWorkspaceOrPackage( manifest.json )"
+    ) == os.path.join(get_package_path(), "manifest.json")


### PR DESCRIPTION
This PR adds the Mock Service to the list of runtime services. With the exposure of variables

`useVehicleMock` (default: `true`) The service can be enabled.

To not collide with feeder CAN, the service can be switched off using the variable

`useFeederCan` (default: `false`)

In your `.velocitas.json`

Both variables are configured as `string` types at the moment since there is a bug in Velocitas CLI which misbehaves with variable type `boolean` and default value `false`