### PR TITLE
Prepare replacement of  env var MQTT_BROKER_URI by SDV_MQTT_ADDRESS

### DIFF
--- a/runtime-k3d/src/app_deployment/config/helm/templates/vehicleapp.yaml
+++ b/runtime-k3d/src/app_deployment/config/helm/templates/vehicleapp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -40,6 +40,10 @@ spec:
           image: "{{ .Values.imageVehicleApp.repository }}:{{ .Values.imageVehicleApp.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.imageVehicleApp.pullPolicy }}
           env:
-          # required for C++ SDK
+          # required for C++ SDK based apps
+          - name: SDV_MQTT_ADDRESS
+            value: tcp://mqttbroker.default.svc.cluster.local:1883
+          # deprecated, required for C++ SDK based apps up to SDK v0.3.2
           - name: MQTT_BROKER_URI
             value: tcp://mqttbroker.default.svc.cluster.local:1883
+

--- a/runtime-k3d/src/app_deployment/config/helm/templates/vehicleapp.yaml
+++ b/runtime-k3d/src/app_deployment/config/helm/templates/vehicleapp.yaml
@@ -46,4 +46,3 @@ spec:
           # deprecated, required for C++ SDK based apps up to SDK v0.3.2
           - name: MQTT_BROKER_URI
             value: tcp://mqttbroker.default.svc.cluster.local:1883
-

--- a/runtime-k3d/src/app_deployment/config/podspec/vehicleapp.yaml
+++ b/runtime-k3d/src/app_deployment/config/podspec/vehicleapp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -35,7 +35,10 @@ spec:
           value: "sampleapp"
         - name: VEHICLEDATABROKER_DAPR_APP_ID
           value: "vehicledatabroker"
-        # required for C++ SDK
+        # required for C++ SDK based apps
+        - name: SDV_MQTT_ADDRESS
+          value: tcp://mqttbroker.default.svc.cluster.local:1883
+        # deprecated, required for C++ SDK based apps up to SDK v0.3.2
         - name: MQTT_BROKER_URI
           value: tcp://mqttbroker.default.svc.cluster.local:1883
 


### PR DESCRIPTION
Prepare to replace the environment variable used to tell the application the address of the MQTT broker: 
Currently used variable is `MQTT_BROKER_URI`, new variable is `SDV_MQTT_ADDRESS`.
The current variable is kept for now to stay compatible with older SDKs using latest k3d runtime.


Required by https://github.com/eclipse-velocitas/vehicle-app-cpp-sdk/issues/59