### PR TITLE
Use native middleware in local runtime

### DIFF
--- a/desired_state_generator/src/requirements.txt
+++ b/desired_state_generator/src/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/desired_state_generator/src/requirements.txt
+++ b/desired_state_generator/src/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3

--- a/runtime.json
+++ b/runtime.json
@@ -101,7 +101,7 @@
             },
             {
                 "key": "env",
-                "value": "VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker"
+                "value": "BROKER_ADDR=localhost:55555"
             },
             {
                 "key": "env",
@@ -131,7 +131,7 @@
             },
             {
                 "key": "env",
-                "value": "VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker"
+                "value": "VDB_ADDRESS=127.0.0.1:55555"
             },
             {
                 "key": "env",
@@ -185,7 +185,7 @@
             },
             {
                 "key": "env",
-                "value": "VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker"
+                "value": "VDB_ADDRESS=127.0.0.1:55555"
             },
             {
                 "key": "mount",

--- a/runtime_k3d/src/requirements.txt
+++ b/runtime_k3d/src/requirements.txt
@@ -1,3 +1,3 @@
 yaspin==2.3.0
 ruamel.yaml==0.17.32
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3

--- a/runtime_k3d/src/requirements.txt
+++ b/runtime_k3d/src/requirements.txt
@@ -1,3 +1,3 @@
 yaspin==2.3.0
 ruamel.yaml==0.17.32
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/runtime_k3d/test/requirements.txt
+++ b/runtime_k3d/test/requirements.txt
@@ -3,4 +3,4 @@ pytest-ordering==0.6
 pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 types-mock==4.0.15.2
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/runtime_k3d/test/requirements.txt
+++ b/runtime_k3d/test/requirements.txt
@@ -3,4 +3,4 @@ pytest-ordering==0.6
 pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 types-mock==4.0.15.2
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3

--- a/runtime_kanto/src/requirements.txt
+++ b/runtime_kanto/src/requirements.txt
@@ -1,2 +1,2 @@
 yaspin==2.3.0
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/runtime_kanto/src/requirements.txt
+++ b/runtime_kanto/src/requirements.txt
@@ -1,2 +1,2 @@
 yaspin==2.3.0
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3

--- a/runtime_kanto/src/runtime/deployment/mockservice.json
+++ b/runtime_kanto/src/runtime/deployment/mockservice.json
@@ -22,7 +22,7 @@
     },
     "config": {
         "env": [
-            "VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker"
+            "VDB_ADDRESS=127.0.0.1:55555"
         ]
     }
 }

--- a/runtime_kanto/src/runtime/deployment/mosquitto.json
+++ b/runtime_kanto/src/runtime/deployment/mosquitto.json
@@ -14,9 +14,6 @@
         }
     },
     "config": {
-        "env": [
-            "KUKSA_DATA_BROKER_PORT=55555"
-        ],
         "cmd": [
             "mosquitto",
             "-c",

--- a/runtime_kanto/test/requirements.txt
+++ b/runtime_kanto/test/requirements.txt
@@ -2,4 +2,4 @@ pytest==7.2.1
 pytest-ordering==0.6
 pytest-asyncio==0.20.3
 pytest-cov==4.0.0
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3

--- a/runtime_kanto/test/requirements.txt
+++ b/runtime_kanto/test/requirements.txt
@@ -2,4 +2,4 @@ pytest==7.2.1
 pytest-ordering==0.6
 pytest-asyncio==0.20.3
 pytest-cov==4.0.0
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/runtime_local/src/requirements.txt
+++ b/runtime_local/src/requirements.txt
@@ -1,2 +1,2 @@
 yaspin==2.3.0
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/runtime_local/src/requirements.txt
+++ b/runtime_local/src/requirements.txt
@@ -1,2 +1,2 @@
 yaspin==2.3.0
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3

--- a/runtime_local/src/run-vehicle-app.py
+++ b/runtime_local/src/run-vehicle-app.py
@@ -42,6 +42,8 @@ def run_app(
         dapr_args = dapr_args + ["--"]
         program_args = dapr_args + program_args
         subprocess.check_call(program_args)
+    else:
+        raise NotImplementedError("Unsupported middleware type!")
 
 
 if __name__ == "__main__":

--- a/runtime_local/src/run-vehicle-app.py
+++ b/runtime_local/src/run-vehicle-app.py
@@ -32,11 +32,13 @@ def run_app(
 ):
     program_args = [executable_path, *args]
     envs = dict()
-    for service in get_services():
-        service_id = service.id
-        envs[get_dapr_app_id(service_id)] = service_id
 
-    if get_middleware_type() == MiddlewareType.DAPR:
+    if get_middleware_type() == MiddlewareType.NATIVE:
+        envs["SDV_MIDDLEWARE_TYPE"] = "native"
+    elif get_middleware_type() == MiddlewareType.DAPR:
+        for service in get_services():
+            service_id = service.id
+            envs[get_dapr_app_id(service_id)] = service_id
         if not app_id:
             app_id = "vehicleapp"
         dapr_args, dapr_env = get_dapr_sidecar_args(app_id, app_port=app_port)
@@ -44,7 +46,7 @@ def run_app(
         envs.update(dapr_env)
         program_args = dapr_args + program_args
 
-    subprocess.check_call(program_args)
+    subprocess.check_call(program_args, env=envs)
 
 
 if __name__ == "__main__":

--- a/runtime_local/src/run-vehicle-app.py
+++ b/runtime_local/src/run-vehicle-app.py
@@ -17,6 +17,7 @@ import subprocess
 from typing import Optional
 
 from local_lib import MiddlewareType, get_dapr_sidecar_args, get_middleware_type
+from velocitas_lib.services import get_service_port
 
 
 def get_dapr_app_id(service_id: str) -> str:
@@ -34,6 +35,12 @@ def run_app(
     if get_middleware_type() == MiddlewareType.NATIVE:
         envs = dict()
         envs["SDV_MIDDLEWARE_TYPE"] = "native"
+        vdb_port = get_service_port("vehicledatabroker")
+        vdb_address = "grpc://127.0.0.1"
+        envs["SDV_VEHICLEDATABROKER_ADDRESS"] = f"{vdb_address}:{vdb_port}"
+        mqtt_port = get_service_port("mqtt-broker")
+        mqtt_address = "mqtt://127.0.0.1"
+        envs["SDV_MQTT_ADDRESS"] = f"{mqtt_address}:{mqtt_port}"
         subprocess.check_call(program_args, env=envs)
     elif get_middleware_type() == MiddlewareType.DAPR:
         if not app_id:

--- a/runtime_local/test/requirements.txt
+++ b/runtime_local/test/requirements.txt
@@ -1,2 +1,2 @@
 pytest==7.2.1
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.2
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native

--- a/runtime_local/test/requirements.txt
+++ b/runtime_local/test/requirements.txt
@@ -1,2 +1,2 @@
 pytest==7.2.1
-git+https://github.com/eclipse-velocitas/velocitas-lib.git@change_to_native
+git+https://github.com/eclipse-velocitas/velocitas-lib.git@v0.0.3


### PR DESCRIPTION
Switch to use the native middleware in the local runtime. (Currently, Dapr middleware is configured as default.)

This serves as preparation to remove the support for the Dapr middleware and k3d runtime (ADO 20005).